### PR TITLE
add new type for get status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.2.1
+
+- **Feature:**
+  - Typing support for indexingEnabled return from getStatus
+
 ## 4.2.0
 
 - **Feature:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dragonchain-sdk",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Dragonchain SDK for Node.JS and the Browser",
   "license": "Apache-2.0",
   "homepage": "https://github.com/dragonchain/dragonchain-sdk-javascript#readme",

--- a/src/interfaces/DragonchainClientInterfaces.ts
+++ b/src/interfaces/DragonchainClientInterfaces.ts
@@ -651,6 +651,7 @@ export interface SmartContractList {
  *   "hashAlgo": "blake2b",
  *   "version": "3.3.1",
  *   "encryptionAlgo": "secp256k1"
+ *   "indexingEnabled": true
  * }
  * ```
  */
@@ -683,6 +684,10 @@ export interface L1DragonchainStatusResult {
    * Encryption algorithm used for blocks on this chain
    */
   encryptionAlgo: string;
+  /**
+   * Whether or not indexing is enabled on this chain
+   */
+  indexingEnabled: boolean;
 }
 
 /**


### PR DESCRIPTION
### Description

Latest dragonchain adds a field for it's get status endpoint, this adds the typing for that

##### Checklist

- [x] `yarn test:ci` passes
- [x] documentation is changed or added
