### PR TITLE
Eternal report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.5
+
+- **Development:**
+  - Add in getEternalReport method
+
 ## 4.3.4
 
 - **Development:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dragonchain-sdk",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "Dragonchain SDK for Node.JS and the Browser",
   "license": "Apache-2.0",
   "homepage": "https://github.com/dragonchain/dragonchain-sdk-javascript#readme",

--- a/src/interfaces/DragonchainClientInterfaces.ts
+++ b/src/interfaces/DragonchainClientInterfaces.ts
@@ -1236,3 +1236,12 @@ export interface PermissionsDocument {
     };
   };
 }
+
+export interface EternalReportV1 {
+  l1Transaction: L1DragonchainTransactionFull;
+  l1Block: BlockSchemaType;
+  l2Verifications: L2BlockAtRest[];
+  l3Verifications: L3BlockAtRest[];
+  l4Verifications: L4BlockAtRest[];
+  l5Verifications: L5BlockAtRest[];
+}

--- a/src/services/dragonchain-client/DragonchainClient.ts
+++ b/src/services/dragonchain-client/DragonchainClient.ts
@@ -57,6 +57,7 @@ import {
   CustomTagFieldOptions,
   SmartContractLogs,
   PermissionsDocument,
+  EternalReportV1,
 } from '../../interfaces/DragonchainClientInterfaces';
 import { CredentialService, HmacAlgorithm } from '../credential-service/CredentialService';
 import { getDragonchainId, getDragonchainEndpoint } from '../config-service';
@@ -1435,6 +1436,32 @@ export class DragonchainClient {
     if (options.gasPrice) body.transaction.gasPrice = options.gasPrice;
     if (options.gas) body.transaction.gas = options.gas;
     return (await this.post('/v1/public-blockchain-transaction', body)) as Response<PublicBlockchainTransactionResponse>;
+  };
+
+  /**
+   * Get/Generate an Eternal-type report given a transaction ID
+   */
+  public getEternalReport = async (options: {
+    /**
+     * the transaction ID of the transaction to generate report for
+     */
+    transactionId: string;
+  }) => {
+    if (!options.transactionId) throw new FailureByDesign('PARAM_ERROR', 'Parameter `transactionId` is required');
+    const transaction = await this.getTransaction({ transactionId: options.transactionId });
+    if (transaction && !transaction.ok) throw new FailureByDesign('NOT_FOUND', 'transaction not found');
+    const blockId = transaction.response.header.block_id;
+    const block = await this.getBlock({ blockId });
+    if (block && !block.ok) throw new FailureByDesign('NOT_FOUND', 'block not found');
+    const verifications = await this.getVerifications({ blockId });
+    return {
+      l1Transaction: transaction.response,
+      l1Block: block.response,
+      l2Verifications: verifications.response && verifications.response['2'],
+      l3Verifications: verifications.response && verifications.response['3'],
+      l4Verifications: verifications.response && verifications.response['4'],
+      l5Verifications: verifications.response && verifications.response['5'],
+    } as EternalReportV1;
   };
 
   /**


### PR DESCRIPTION
# Description 

Implements new request: `getEternalReport` which generates an eternal-type report given a transaction ID 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `yarn test:ci` passes
- [x] tests are included
- [x] documentation is changed or added
